### PR TITLE
fix: installations in uac protected folders can now run without admin…

### DIFF
--- a/eddisplay.go
+++ b/eddisplay.go
@@ -119,24 +119,32 @@ func onReady() {
 		log.SetLevel(logLevel)
 		log.SetFormatter(&TextLogFormatter{})
 
-		// Ensure logs directory exists
-		logDir := "logs"
+		// Use %APPDATA%\EDxDC for config and logs
+		appDataDir, err := os.UserConfigDir()
+		if err != nil {
+			log.Fatalln("Could not determine user config dir:", err)
+		}
+		baseDir := filepath.Join(appDataDir, "EDxDC")
+		_ = os.MkdirAll(baseDir, 0755)
+
+		// Logs directory inside baseDir
+		logDir := filepath.Join(baseDir, "logs")
 		_ = os.MkdirAll(logDir, 0755)
 		logFileName := time.Now().Format("2006-01-02_15.04.05") + ".log"
 		logPath := filepath.Join(logDir, logFileName)
 
-		// Set up log rotation
 		log.SetOutput(&lumberjack.Logger{
 			Filename:   logPath,
-			MaxSize:    10, // megabytes
+			MaxSize:    10,
 			MaxBackups: 5,
-			MaxAge:     30,   //days
-			Compress:   true, // compress old logs
+			MaxAge:     30,
+			Compress:   true,
 		})
 
 		log.Infof("Logging to %s", logPath)
 
-		conf := conf.LoadConf()
+		confPath := filepath.Join(baseDir, "main.conf")
+		conf := conf.LoadOrCreateConf(confPath)
 
 		// Calculate number of enabled pages
 		pageCount := 0

--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -71,8 +71,11 @@ procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 begin
   if CurUninstallStep = usUninstall then begin
     if not RetainLogs then
-      DelTree(ExpandConstant('{app}\logs'), True, True, True);
+      DelTree(ExpandConstant('{userappdata}\EDxDC\logs'), True, True, True);
     if not RetainConf then
-      DeleteFile(ExpandConstant('{app}\conf.yaml'));
+      DeleteFile(ExpandConstant('{userappdata}\EDxDC\conf.yaml'));
+    // If neither logs nor conf are retained, remove the whole directory
+    if (not RetainLogs) and (not RetainConf) then
+      DelTree(ExpandConstant('{userappdata}\EDxDC'), True, True, True);
   end;
 end;


### PR DESCRIPTION
… privileges

conf.yaml is now main.conf and is generated on first start. Conf and logs are now generated in %appdata%\EDxDC allowing the app to run in UAC protected folders without admin privileges.